### PR TITLE
Don't restrict node version by 8+

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,6 @@
         "mocha": "~3.5.1",
         "nsp": "~2.8.0"
     },
-    "engines": {
-        "node": "^8.4.0",
-        "npm": "^5.4.1"
-    },
     "eslintConfig": {
         "env": {
             "browser": true,


### PR DESCRIPTION
Requiring node version 8+ seems to be not very reasonable. I'm using this plugin to log more details of some micro-service deployed on AWS Lambda. Latest node version Lambda supports is `v6.10` atm: http://docs.aws.amazon.com/lambda/latest/dg/programming-model.html. So, requested change should make life of Lambda users easier.