### PR TITLE
Create identifier that includes the source path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # babel-plugin-transform-line
-Replaces the identifier __line with the source line number.
+Replaces the identifier `__line` with the source line number and `__fileline` with the relative source path as well as the line number.
 
 ![](https://img.shields.io/badge/tests-passing-brightgreen.svg)
 ![](https://img.shields.io/badge/coverage-100%25-brightgreen.svg)

--- a/js/babel-plugin-transform-line.js
+++ b/js/babel-plugin-transform-line.js
@@ -1,5 +1,9 @@
 'use strict';
 
+const _normalizePathSep = function (path) {
+    return path.replace(/\\/gu, '/');
+};
+
 module.exports = ({
     types
 }) => {
@@ -7,7 +11,7 @@ module.exports = ({
 
     return {
         visitor: {
-            ReferencedIdentifier (path) {
+            ReferencedIdentifier (path, state) {
                 if (path.node.name === '__line') {
                     const location = path.node.loc;
 
@@ -16,6 +20,18 @@ module.exports = ({
                             types.numericLiteral(location.start.line) :
                             void0Expression
                     );
+                } else if (path.node.name === '__fileline') {
+                    const filename = _normalizePathSep(state.file.opts.filename),
+                        location = path.node.loc,
+                        root = _normalizePathSep(state.file.opts.root);
+
+                    let sourceString = filename.substring(root.length);
+
+                    if (location && location.start.line) {
+                        sourceString += `:${location.start.line}`;
+                    }
+
+                    path.replaceWith(types.stringLiteral(sourceString));
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
             "node": true
         },
         "extends": "plugin:isotropic/isotropic",
+        "globals": {
+            "__fileline": "readonly"
+        },
         "parserOptions": {
             "ecmaFeatures": {
                 "globalReturn": false,

--- a/test/babel-plugin-transform-line.js
+++ b/test/babel-plugin-transform-line.js
@@ -16,3 +16,9 @@ _mocha.describe('__line', () => {
         _chai.expect(__someOtherDynamicCode).to.be.undefined;
     });
 });
+
+_mocha.describe('__fileline', () => {
+    _mocha.it('should represent the current filepath and line number', () => {
+        _chai.expect(__fileline).to.equal('/test/babel-plugin-transform-line.js:22');
+    });
+});


### PR DESCRIPTION
Create the `__fileline` identifier which will get replaced with the
source path, relative to the package root, as well as the line number.